### PR TITLE
Prevent NumberFormatException when strings consist only of numbers

### DIFF
--- a/src/main/java/com/github/terma/sqlonjson/SqlOnJson.java
+++ b/src/main/java/com/github/terma/sqlonjson/SqlOnJson.java
@@ -94,7 +94,8 @@ public class SqlOnJson {
                     }
                 }
 
-                cls.put(part.getKey(), columnType);
+                ColumnType current = cls.get(part.getKey());
+                if (current == null || current != ColumnType.STRING) cls.put(part.getKey(), columnType);
             }
         }
         return cls;

--- a/src/test/java/com/github/terma/sqlonjson/SqlOnJsonTest.java
+++ b/src/test/java/com/github/terma/sqlonjson/SqlOnJsonTest.java
@@ -163,6 +163,18 @@ public class SqlOnJsonTest {
     }
 
     @Test
+    public void representNumericStringAsString() throws Exception {
+        try (Connection c = sqlOnJson.convertPlain("{t:[{a:\"super\"},{a:\"5\"}]}")) {
+            ResultSet rs = c.prepareStatement("select * from t").executeQuery();
+            rs.next();
+            Assert.assertEquals("super", rs.getString("a"));
+            rs.next();
+            Assert.assertEquals("5", rs.getString("a"));
+            Assert.assertFalse(rs.next());
+        }
+    }
+
+    @Test
     public void supportEmbeddedArrayToTable() throws Exception {
         try (Connection c = sqlOnJson.convertPlain("{orders:[{em:[{a:-7}]}]}")) {
             ResultSet rs1 = c.prepareStatement("select * from orders").executeQuery();


### PR DESCRIPTION
This prevents NumberFormatException from being thrown if the last value for a string field consists strictly of numbers.

Previously the below would throw an exception when running a `select` query:
```
"data": [
  {"a": "super"},
  {"a": "5"}
]
```